### PR TITLE
Add support for spanish "es" locale

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -142,6 +142,7 @@ Here are some examples demonstrating the usage of the functions provided by the 
 
 #custom-date-format(my-date, "DD-MM-YYYY")  // Output: 25-12-2024
 #custom-date-format(my-date, "Day, DD Month YYYY", "fr")  // Output: Mercredi, 25 Décembre 2024
+#custom-date-format(my-date, "day, DD de month de YYYY", "es") // Output: miércoles, 25 de diciembre de 2024
 
 #day-name(4)  // Output: thursday
 
@@ -191,7 +192,7 @@ Here are some examples demonstrating the usage of the functions provided by the 
 | el             | ❌           |
 | en             | ✅           |
 | eo             | ❌           |
-| es             | ❌           |
+| es             | ✅           |
 | et             | ❌           |
 | eu             | ❌           |
 | fa             | ❌           |

--- a/src/translations/day_name.toml
+++ b/src/translations/day_name.toml
@@ -24,3 +24,12 @@
 5 = "freitag"
 6 = "samstag"
 7 = "sonntag"
+
+[es]
+1 = "lunes"
+2 = "martes"
+3 = "miércoles"
+4 = "jueves"
+5 = "viernes"
+6 = "sábado"
+7 = "domingo"

--- a/src/translations/month_name.toml
+++ b/src/translations/month_name.toml
@@ -39,3 +39,17 @@
 10 = "oktober"
 11 = "november"
 12 = "dezember"
+
+[es]
+1 = "enero"
+2 = "febrero"
+3 = "marzo"
+4 = "abril"
+5 = "mayo"
+6 = "junio"
+7 = "julio"
+8 = "agosto"
+9 = "septiembre"
+10 = "octubre"
+11 = "noviembre"
+12 = "diciembre"

--- a/tests/test_formats.typ
+++ b/tests/test_formats.typ
@@ -15,3 +15,9 @@
 
 #let french_date = datetime(year: 2024, month: 8, day: 23)
 #assert(custom-date-format(french_date, "Day, DD MMM YYYY", "fr") == "Vendredi, 23 aoû 2024")
+
+#let spanish_date = datetime(year: 2023, month: 2, day: 23)
+#assert(custom-date-format(spanish_date, "day, DD de month de YYYY", "es") == "jueves, 23 de febrero de 2023")
+
+#let spanish_date = datetime(year: 2024, month: 8, day: 9)
+#assert(custom-date-format(spanish_date, "day, DD de month de YYYY", "es") == "viernes, 09 de agosto de 2024")

--- a/tests/test_translations.typ
+++ b/tests/test_translations.typ
@@ -6,3 +6,5 @@
 #assert(month-name(1, "fr") == "janvier")
 #assert(day-name(1, "en", true) == "Monday")
 #assert(month-name(1, "en", true) == "January")
+#assert(day-name(1, "es") == "lunes")
+#assert(month-name(1, "es") == "enero")


### PR DESCRIPTION
Hi! I've added support for spanish dates.

- I updated the month translation toml
- I updated the day translation toml
- I added tests for both custom formats and translations

Some notes about dates in spanish, for anyone interested in including localized dates in their documents:

- Ascending order: In spanish the order is `day name, day number, month, year`.
- Prepositions: In spanish days are "of" the month and months are "of" the year, so the preposition "de" is used accordingly.
- Comma separated: the day name goes separated by a comma from the actual full date
- Capitalization: Day and month names are **only** capitalized in spanish when it is the beginning of a sentence.

[Source 1](https://www.rae.es/ortograf%C3%ADa/modelos-de-expresi%C3%B3n-de-la-fecha)
[Source 2](https://www.rae.es/espanol-al-dia/mayuscula-o-minuscula-en-los-meses-los-dias-de-la-semana-y-las-estaciones-del-ano)

Given this, I've also included an example of a spanish custom date format in the examples section of the readme c:

Some examples of how it looks:

```typst
#day-name(2, "es", true) // Output: Martes

#month-name(3, "es") // Output: marzo

#let spanish_date = datetime(year: 2023, month: 8, day: 9)
#custom-date-format(spanish_date, "day, DD de month de YYYY", "es") // Output: miércoles, 09 de agosto de 2023

#let my-date = datetime(year: 2024, month: 12, day: 23)
#custom-date-format(my-date, "day, DD de month de YYYY", "es") // Output: lunes, 23 de diciembre de 2024
```

Let me know if this is up to your standard to be merged, and if not, please let me know what I'm missing or what I can improve :D
