### PR TITLE
Fixed issue with clusters in `src/utils.typ` (and added tests)

### DIFF
--- a/src/utils.typ
+++ b/src/utils.typ
@@ -1,5 +1,5 @@
 #let first-letter-to-upper = (s) => {
-  upper(s.first()) + s.codepoints().slice(1).join()
+  upper(s.first()) + s.clusters().slice(1).join()
 }
 
 // Take a number as an input and a length,

--- a/tests/test_utils.typ
+++ b/tests/test_utils.typ
@@ -4,6 +4,8 @@
 
 #assert(first-letter-to-upper("hello") == "Hello")
 #assert(first-letter-to-upper("world") == "World")
+#assert(first-letter-to-upper("שלום") == "שלום")
+#assert(first-letter-to-upper("שָׁלוֹם") == "שָׁלוֹם")
 #assert(pad(5, 2) == "05")
 #assert(pad(123, 5) == "00123")
 #assert(safe-slice("Août", 3) == "Aoû")


### PR DESCRIPTION
In a [previous pr](https://github.com/Jeomhps/datify/pull/4#issue-2664738096) I changed:

```typst
#let first-letter-to-upper = (s) => {
  upper(s.first()) + s.slice(1)
}
```

Into:

```typst
#let first-letter-to-upper = (s) => {
  upper(s.first()) + s.codepoints().slice(1).join()
}
```

Which made it possible to pass strings with non-latin characters to the function, but this is wrong as `string.first` returns the first cluster of the string, not the first codepoint, which means if the first code cluster isn't a single character this will repeat any markings on it twice:

```typst
#assert(first-letter-to-upper("שלום") == "שלום") // passes
#assert(first-letter-to-upper("שָׁלוֹם") == "שָׁלוֹם") // failes
```

So I changed it to use clusters:

```typst
#let first-letter-to-upper = (s) => {
  upper(s.first()) + s.clusters().slice(1).join()
}
```

Now it works:

```typst
#assert(first-letter-to-upper("שלום") == "שלום") // passes
#assert(first-letter-to-upper("שָׁלוֹם") == "שָׁלוֹם") // passes

// PS: this was added as a test in tests/test_utils.typ
```