### PR TITLE
Added Austrian language variant

### DIFF
--- a/src/translations/day_name.toml
+++ b/src/translations/day_name.toml
@@ -25,6 +25,15 @@
 6 = "samstag"
 7 = "sonntag"
 
+[de-AT]
+1 = "montag"
+2 = "dienstag"
+3 = "mittwoch"
+4 = "donnerstag"
+5 = "freitag"
+6 = "samstag"
+7 = "sonntag"
+
 [es]
 1 = "lunes"
 2 = "martes"

--- a/src/translations/month_name.toml
+++ b/src/translations/month_name.toml
@@ -40,6 +40,20 @@
 11 = "november"
 12 = "dezember"
 
+[de-AT]
+1 = "jänner"
+2 = "feber"
+3 = "märz"
+4 = "april"
+5 = "mai"
+6 = "juni"
+7 = "juli"
+8 = "august"
+9 = "september"
+10 = "oktober"
+11 = "november"
+12 = "dezember"
+
 [es]
 1 = "enero"
 2 = "febrero"

--- a/tests/test_formats.typ
+++ b/tests/test_formats.typ
@@ -1,6 +1,6 @@
 // To compile this file : typst compile --root .. .\test_formats.typ
 
-#import "../src/formats.typ": custom-date-format 
+#import "../src/formats.typ": custom-date-format
 
 #let date = datetime(year: 2024, month: 8, day: 29)
 
@@ -39,3 +39,6 @@
 
 #let catalan_date = datetime(year: 2025, month: 1, day: 9)
 #assert(custom-date-format(catalan_date, "divendres, DD de month de YYYY", "ca") == "divendres, 09 de gener de 2025")
+
+#let german_austrian_date = datetime(year: 2025, month: 1, day: 9)
+#assert(custom-date-format(german_austrian_date, "Month DD, YYYY", "de-AT") == "Jänner 09, 2025")

--- a/tests/test_translations.typ
+++ b/tests/test_translations.typ
@@ -14,3 +14,6 @@
 #assert(month-name(1, "he") == "ינואר")
 #assert(day-name(1, "ca") == "dilluns")
 #assert(month-name(1, "ca") == "gener")
+#assert(day-name(1, "de-AT") == "montag")
+#assert(month-name(1, "de-AT") == "jänner")
+#assert(month-name(2, "de-AT") == "feber")


### PR DESCRIPTION
This adds a language variant to the default German under the `de-AT` tag.

**Why?**

Austria (for some reason) uses different words for two of the months, and it'd be awesome if those where to be added to this lovely package!

I also included some relevant tests, as you requested in other PRs.