### PR TITLE
Add short format option (e.g. 2025-4-4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,12 +120,14 @@ Below is a table of all possible format types that can be used in the format str
 | Format | Description                            | Example       |
 |--------|----------------------------------------|---------------|
 | `DD`   | Day of the month, 2 digits             | 05            |
+| `dD`   | Day of the month, 1 digit              | 5             |
 | `day`  | Full name of the day                   | tuesday       |
 | `Day`  | Capitalized full name of the day       | Tuesday       |
 | `DAY`  | Uppercase full name of the day         | TUESDAY       |
 | `MMMM` | Capitalized full name of the month     | May           |
 | `MMM`  | Short name of the month (first 3 chars)| May           |
 | `MM`   | Month number, 2 digits                 | 05            |
+| `mM`   | Month number, 1 digit                  | 5             |
 | `month`| Full name of the month                 | may           |
 | `Month`| Capitalized full name of the month     | May           |
 | `MONTH`| Uppercase full name of the month       | MAY           |

--- a/src/formats.typ
+++ b/src/formats.typ
@@ -19,6 +19,8 @@
   let year = str(date.year())
   let weekday = date.weekday()
 
+  let short-day = str(date.day())
+  let short-month = str(date.month())
   let short-year = year.slice(-2)
 
   // Uses the name function to return name in the correct languages
@@ -40,6 +42,7 @@
   let formatted = format
     // Day formats
     .replace("DD", day)
+    .replace("dD", short-day)
     .replace("day", full-day)
     .replace("Day", capitalized-day)
     .replace("DAY", uppercase-day)
@@ -48,6 +51,7 @@
     .replace("MMMM", capitalized-month)
     .replace("MMM", short-month-name)
     .replace("MM", month)
+    .replace("mM", short-month)
     .replace("month", full-month)
     .replace("Month", capitalized-month)
     .replace("MONTH", uppercase-month)

--- a/tests/test_formats.typ
+++ b/tests/test_formats.typ
@@ -10,6 +10,12 @@
 #assert(custom-date-format(date, "month DD, YYYY") == "august 29, 2024")
 #assert(custom-date-format(date, "month DDth, YYYY") == "august 29th, 2024")
 
+#let shortdate = datetime(year: 2025, month: 4, day: 4)
+
+#assert(custom-date-format(shortdate, "dD. MM. YYYY") == "4. 04. 2025")
+#assert(custom-date-format(shortdate, "DD. mM. YYYY") == "04. 4. 2025")
+#assert(custom-date-format(shortdate, "dD. mM. YYYY") == "4. 4. 2025")
+
 #let french_date = datetime(year: 2024, month: 5, day: 23)
 #assert(custom-date-format(french_date, "Day, DD Month YYYY", "fr") == "Jeudi, 23 Mai 2024")
 

--- a/tests/test_formats.typ
+++ b/tests/test_formats.typ
@@ -9,6 +9,7 @@
 #assert(custom-date-format(date, "Month DD, YYYY") == "August 29, 2024")
 #assert(custom-date-format(date, "month DD, YYYY") == "august 29, 2024")
 #assert(custom-date-format(date, "month DDth, YYYY") == "august 29th, 2024")
+#assert(custom-date-format(date, "YYYY-mM-dD") == "2024-8-29")
 
 #let shortdate = datetime(year: 2025, month: 4, day: 4)
 


### PR DESCRIPTION
Adds two options:

- `dD` for single-digit day
- `mM` for single-digit month

alongside tests and documentation.

I'm still uncertain about the format specifier, but these were the best ones i could come up with for now. `D` and `M` can't be used as the replacement operation would clash with either `Day` or `Month`, resulting in undesirable outcomes.