### PR TITLE
Add Italian (it) language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ Here are some examples demonstrating the usage of the functions provided by the 
 | ik             | ❌           |
 | io             | ❌           |
 | is             | ❌           |
-| it             | ❌           |
+| it             | ✅           |
 | iu             | ❌           |
 | ja             | ❌           |
 | jv             | ❌           |

--- a/src/translations/day_name.toml
+++ b/src/translations/day_name.toml
@@ -87,3 +87,12 @@
 5 = "vrijdag"
 6 = "zaterdag"
 7 = "zondag"
+
+[it]
+1 = "lunedì"
+2 = "martedì"
+3 = "mercoledì"
+4 = "giovedì"
+5 = "venerdì"
+6 = "sabato"
+7 = "domenica"

--- a/src/translations/month_name.toml
+++ b/src/translations/month_name.toml
@@ -137,3 +137,17 @@
 10 = "oktober"
 11 = "november"
 12 = "december"
+
+[it]
+1 = "gennaio"
+2 = "febbraio"
+3 = "marzo"
+4 = "aprile"
+5 = "maggio"
+6 = "giugno"
+7 = "luglio"
+8 = "agosto"
+9 = "settembre"
+10 = "ottobre"
+11 = "novembre"
+12 = "dicembre"

--- a/tests/test_formats.typ
+++ b/tests/test_formats.typ
@@ -63,3 +63,10 @@
 
 #let dutch_date = datetime(year: 2024, month: 12, day: 7)
 #assert(custom-date-format(dutch_date, "day, DD month YYYY", "nl") == "zaterdag, 07 december 2024")
+
+// Italian [it]
+#let italian_date = datetime(year: 2017, month: 3, day: 14)
+#assert(custom-date-format(italian_date, "day, DD month YYYY", "it") == "martedì, 14 marzo 2017")
+
+#let italian_date = datetime(year: 2025, month: 6, day: 15)
+#assert(custom-date-format(italian_date, "Day DD month YYYY", "it") == "Domenica 15 giugno 2025")

--- a/tests/test_translations.typ
+++ b/tests/test_translations.typ
@@ -23,3 +23,7 @@
 #assert(month-name(1, "nl") == "januari")
 #assert(day-name(1, "de") == "montag")
 #assert(month-name(1, "de") == "januar")
+#assert(day-name(1, "it") == "lunedì")
+#assert(day-name(6, "it") == "sabato")
+#assert(month-name(1, "it") == "gennaio")
+#assert(month-name(5, "it") == "maggio")


### PR DESCRIPTION
Hi, 

I've added the support for the Italian language [**it**].
I edited both the month and day files (`translation/month_name.toml` and `translation/day_name.toml`), and added some tests for the translations and formats. Finally, this PR also changes the emoji for the Italian entry in the `README.dm` file from ❌ to ✅. If that's a problem, just tell me and I'll re-do the PR.

Thanks,

MD