### PR TITLE
Short name for capitalized months

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,22 +117,23 @@ custom-date-format(date: datetime, format: str, lang: str = 'en') -> str
 
 Below is a table of all possible format types that can be used in the format string:
 
-| Format | Description                            | Example       |
-|--------|----------------------------------------|---------------|
-| `DD`   | Day of the month, 2 digits             | 05            |
-| `dD`   | Day of the month, 1 digit              | 5             |
-| `day`  | Full name of the day                   | tuesday       |
-| `Day`  | Capitalized full name of the day       | Tuesday       |
-| `DAY`  | Uppercase full name of the day         | TUESDAY       |
-| `MMMM` | Capitalized full name of the month     | May           |
-| `MMM`  | Short name of the month (first 3 chars)| May           |
-| `MM`   | Month number, 2 digits                 | 05            |
-| `mM`   | Month number, 1 digit                  | 5             |
-| `month`| Full name of the month                 | may           |
-| `Month`| Capitalized full name of the month     | May           |
-| `MONTH`| Uppercase full name of the month       | MAY           |
-| `YYYY` | 4-digit year                           | 2023          |
-| `YY`   | Last 2 digits of the year              | 23            |
+| Format | Description                                        | Example       |
+|--------|----------------------------------------------------|---------------|
+| `DD`   | Day of the month, 2 digits                         | 05            |
+| `dD`   | Day of the month, 1 digit                          | 5             |
+| `day`  | Full name of the day                               | tuesday       |
+| `Day`  | Capitalized full name of the day                   | Tuesday       |
+| `DAY`  | Uppercase full name of the day                     | TUESDAY       |
+| `MMMM` | Capitalized full name of the month                 | May           |
+| `MMM`  | Short name of the capitalized month (first 3 chars)| May           |
+| `mmm`  | Short name of the month (first 3 chars)            | may           |
+| `MM`   | Month number, 2 digits                             | 05            |
+| `mM`   | Month number, 1 digit                              | 5             |
+| `month`| Full name of the month                             | may           |
+| `Month`| Capitalized full name of the month                 | May           |
+| `MONTH`| Uppercase full name of the month                   | MAY           |
+| `YYYY` | 4-digit year                                       | 2023          |
+| `YY`   | Last 2 digits of the year                          | 23            |
 
 
 ## Examples

--- a/src/formats.typ
+++ b/src/formats.typ
@@ -37,6 +37,7 @@
 
   // Short name for months, i.e January = Jan
   let short-month-name =  if full-month.len() > 3 { safe-slice(full-month, 3) } else { full-month }
+  let short-capitalized-month-name =  if capitalized-month.len() > 3 { safe-slice(capitalized-month, 3) } else { capitalized-month }
 
   // Format the arg format in the right form and returns it.
   let formatted = format
@@ -49,7 +50,8 @@
 
     // Month formats
     .replace("MMMM", capitalized-month)
-    .replace("MMM", short-month-name)
+    .replace("MMM", short-capitalized-month-name)
+    .replace("mmm", short-month-name)
     .replace("MM", month)
     .replace("mM", short-month)
     .replace("month", full-month)

--- a/tests/test_formats.typ
+++ b/tests/test_formats.typ
@@ -21,7 +21,10 @@
 #assert(custom-date-format(french_date, "Day, DD Month YYYY", "fr") == "Jeudi, 23 Mai 2024")
 
 #let french_date = datetime(year: 2024, month: 8, day: 23)
-#assert(custom-date-format(french_date, "Day, DD MMM YYYY", "fr") == "Vendredi, 23 aoû 2024")
+#assert(custom-date-format(french_date, "Day, DD mmm YYYY", "fr") == "Vendredi, 23 aoû 2024")
+
+#let french_date = datetime(year: 2024, month: 8, day: 23)
+#assert(custom-date-format(french_date, "Day, DD MMM YYYY", "fr") == "Vendredi, 23 Aoû 2024")
 
 #let spanish_date = datetime(year: 2023, month: 2, day: 23)
 #assert(custom-date-format(spanish_date, "day, DD de month de YYYY", "es") == "jueves, 23 de febrero de 2023")


### PR DESCRIPTION
Fixed `MMM` formatting to produce capitalized 3-letter months (e.g., "Jan") per [documentation](https://github.com/Jeomhps/datify/blob/7f08d03cb855dde8fe9bcd0bc7b5e6a9bedb4a0f/README.md#format-types).

Introduced `mmm` format to maintain previous lowercase behaviour of `MMM`(e.g., "jan").