### PR TITLE
Add Malay (Bahasa Malaysia) translation for day and month names, plus tests

### DIFF
--- a/src/translations/day_name.toml
+++ b/src/translations/day_name.toml
@@ -105,3 +105,12 @@
 5 = "venerdì"
 6 = "sabato"
 7 = "domenica"
+
+[my]
+1 = "isnin"
+2 = "selasa"
+3 = "rabu"
+4 = "khamis"
+5 = "jumaat"
+6 = "sabtu"
+7 = "ahad"

--- a/src/translations/month_name.toml
+++ b/src/translations/month_name.toml
@@ -165,3 +165,17 @@
 10 = "ottobre"
 11 = "novembre"
 12 = "dicembre"
+
+[my]
+1 = "januari"
+2 = "fabruari"
+3 = "mac"
+4 = "april"
+5 = "mei"
+6 = "jun"
+7 = "julai"
+8 = "ogos"
+9 = "september"
+10 = "oktober"
+11 = "november"
+12 = "disember"

--- a/tests/test_formats.typ
+++ b/tests/test_formats.typ
@@ -80,3 +80,10 @@
 
 #let italian_date = datetime(year: 2025, month: 6, day: 15)
 #assert(custom-date-format(italian_date, "Day DD month YYYY", "it") == "Domenica 15 giugno 2025")
+
+// Malay [my]
+#let malay_date = datetime(year: 2025, month: 8, day: 19)
+#assert(custom-date-format(malay_date, "day, DD month YYYY", "my") == "selasa, 19 ogos 2025")
+#assert(custom-date-format(malay_date, "Day, DD Month YYYY", "my") == "Selasa, 19 Ogos 2025")
+#assert(custom-date-format(malay_date, "day, DD MMM YYYY", "my") == "selasa, 19 Ogo 2025")
+#assert(custom-date-format(malay_date, "day, DD mmm YYYY", "my") == "selasa, 19 ogo 2025")

--- a/tests/test_translations.typ
+++ b/tests/test_translations.typ
@@ -29,3 +29,5 @@
 #assert(day-name(6, "it") == "sabato")
 #assert(month-name(1, "it") == "gennaio")
 #assert(month-name(5, "it") == "maggio")
+#assert(day-name(1, "my") == "isnin")
+#assert(month-name(1, "my") == "januari")


### PR DESCRIPTION
This pull request adds support for Malay (Bahasa Malaysia) in the date formatting library:

Added Malay translations for day and month names in day_name.toml and month_name.toml.
Added comprehensive tests for Malay in test_translations.typ and test_formats.typ.
Ensures correct formatting and capitalization for Malay dates.